### PR TITLE
Fix 'precedes', 'extends' in non-Unicode terminals

### DIFF
--- a/plugin/cream-showinvisibles.vim
+++ b/plugin/cream-showinvisibles.vim
@@ -159,7 +159,11 @@ function! Cream_listchars_init()
 	elseif     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
 		" ellipses
 		execute "set listchars+=precedes:" . nr2char(133)
+	elseif strlen(substitute(strtrans(nr2char(8230)), ".", "x", "g")) == 1
+		" ellipses (2nd try)
+		execute "set listchars+=precedes:" . nr2char(8230)
 	elseif strlen(substitute(strtrans(nr2char(8249)), ".", "x", "g")) == 1
+	\&& v:lang != "C"
 		" mathematical lessthan (digraph <1)
 		execute "set listchars+=precedes:" . nr2char(8249)
 	elseif strlen(substitute(strtrans(nr2char(8592)), ".", "x", "g")) == 1
@@ -178,7 +182,11 @@ function! Cream_listchars_init()
 	elseif     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
 		" ellipses
 		execute "set listchars+=extends:" . nr2char(133)
+	elseif strlen(substitute(strtrans(nr2char(8230)), ".", "x", "g")) == 1
+		" ellipses (2nd try)
+		execute "set listchars+=extends:" . nr2char(8230)
 	elseif strlen(substitute(strtrans(nr2char(8250)), ".", "x", "g")) == 1
+	\&& v:lang != "C"
 		" mathematical greaterthan (digraph >1)
 		execute "set listchars+=extends:" . nr2char(8250)
 	elseif strlen(substitute(strtrans(nr2char(8594)), ".", "x", "g")) == 1

--- a/plugin/cream-showinvisibles.vim
+++ b/plugin/cream-showinvisibles.vim
@@ -1,6 +1,6 @@
 "======================================================================
 " cream-showinvisibles.vim
-" 
+"
 " Cream -- An easy-to-use configuration of the famous Vim text editor
 " [ http://cream.sourceforge.net ] Copyright (C) 2002-2004  Steve Hall
 "
@@ -37,7 +37,7 @@
 "
 " This is one of the many custom utilities and functions for gVim from
 " the Cream project (http://cream.sourceforge.net), a configuration of
-" Vim for those of us familiar with Apple and Windows software. 
+" Vim for those of us familiar with Apple and Windows software.
 "
 " Updated: 2004 March 20
 " Version: 3.01
@@ -131,7 +131,7 @@ function! Cream_listchars_init()
 		" greaterthan, followed by space
 		execute "set listchars+=tab:" . nr2char(62) . '\ '
 	endif
-		
+
 	" eol
 	if     strlen(substitute(strtrans(nr2char(182)), ".", "x", "g")) == 1
 		" paragrah symbol (digraph PI)
@@ -152,7 +152,11 @@ function! Cream_listchars_init()
 	endif
 
 	" precedes
-	if     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
+	if !has("gui_running") && &termencoding != "utf-8"
+	"elseif Cream_has("ms") && &encoding == "utf-8"
+		" underscore
+		execute "set listchars+=precedes:" . nr2char(95)
+	elseif     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
 		" ellipses
 		execute "set listchars+=precedes:" . nr2char(133)
 	elseif strlen(substitute(strtrans(nr2char(8249)), ".", "x", "g")) == 1
@@ -167,7 +171,11 @@ function! Cream_listchars_init()
 	endif
 
 	" extends
-	if     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
+	if !has("gui_running") && &termencoding != "utf-8"
+	"elseif Cream_has("ms") && &encoding == "utf-8"
+		" underscore
+		execute "set listchars+=extends:" . nr2char(95)
+	elseif     strlen(substitute(strtrans(nr2char(133)), ".", "x", "g")) == 1
 		" ellipses
 		execute "set listchars+=extends:" . nr2char(133)
 	elseif strlen(substitute(strtrans(nr2char(8250)), ".", "x", "g")) == 1


### PR DESCRIPTION
This incorporates a fix from [Cream](http://cream.sourceforge.net/) 0.4.3 which has been unmaintained since 2011. Their version checks for ancient versions of vim which I didn't include.

Running xterm (not uxterm) with LC_ALL=en_US results in `precedes` and `extends` showing up as an upside-down question mark (`:set listchars`), which is xterm's way of letting the user know there's a character it doesn't recognize. This fix sets `&listchars=tab:» ,eol:¶,trail:·,precedes:_,extends:_` when the terminal doesn't support Unicode.

I also stripped the trailing whitespace.
